### PR TITLE
Change scapy requirement from GitHub to Pypi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ netifaces==0.10.5
 python-nmap==0.6.1
 PyYAML==3.12
 requests==2.12.1
-https://github.com/phaethon/scapy.git
+scapy>=2.4.3
 texttable==0.8.7


### PR DESCRIPTION
I had problem while installing lanscan by not installing scapy module. Fixed after installing module from PyPi like other modules in requirements. Install via pip3 on Ubuntu 18.04